### PR TITLE
fix / ファイルが存在しない場合にアプリが落ちる不具合を修正

### DIFF
--- a/Musicer/Models/Files/DirectoryExpander.cs
+++ b/Musicer/Models/Files/DirectoryExpander.cs
@@ -4,6 +4,12 @@
     {
         public static ExtendFileInfo ExpandDirectories(ExtendFileInfo rootDirectory, ExtendFileInfo targetPath)
         {
+            // targetPath のファイルが存在しない場合
+            if (!targetPath.FileSystemInfo.Exists)
+            {
+                return null;
+            }
+
             if (targetPath.FileSystemInfo.FullName == rootDirectory.FileSystemInfo.FullName)
             {
                 // 目的となるパスがルートディレクトリと同じなら、ルートディレクトリだけ展開して終了

--- a/Musicer/Models/Files/ExtendFileInfo.cs
+++ b/Musicer/Models/Files/ExtendFileInfo.cs
@@ -14,6 +14,12 @@
 
         public ExtendFileInfo(string path)
         {
+            if (!File.Exists(path) && !Directory.Exists(path))
+            {
+                FileSystemInfo = new FileInfo(path);
+                return;
+            }
+
             IsDirectory = File.GetAttributes(path).HasFlag(FileAttributes.Directory);
 
             if (IsDirectory)


### PR DESCRIPTION
アプリをあるディレクトリを選択して終了、その後アプリを再起動した時、選択していたファイルやディレクトリがなんらかの原因で存在しなかった場合の処理を追加。
